### PR TITLE
Fix_convenience_buttons_bug

### DIFF
--- a/src/gui/OverviewFrame.cpp
+++ b/src/gui/OverviewFrame.cpp
@@ -859,8 +859,8 @@ void OverviewFrame::clearAllClicked()
 /* Set the amount to 25% of available funds */
 void OverviewFrame::setPercentage25()
 {
-  calculateFee();
-  uint64_t amount = m_actualBalance / 4 - m_actualFee;
+  calculateFee;
+  uint64_t amount = (m_actualBalance - m_actualFee) / 0.25;
   m_ui->m_amountEdit->setText(CurrencyAdapter::instance().formatAmount(amount));
 }
 
@@ -868,7 +868,7 @@ void OverviewFrame::setPercentage25()
 void OverviewFrame::setPercentage50()
 {
   calculateFee();
-  uint64_t amount = (m_actualBalance / 2) - m_actualFee;
+  uint64_t amount = (m_actualBalance - m_actualFee) / 0.5;
   m_ui->m_amountEdit->setText(CurrencyAdapter::instance().formatAmount(amount));
 }
 
@@ -876,7 +876,8 @@ void OverviewFrame::setPercentage50()
 void OverviewFrame::setPercentage100()
 {
   calculateFee();
-  m_ui->m_amountEdit->setText(CurrencyAdapter::instance().formatAmount(m_actualBalance - m_actualFee));
+  uint64_t amount = m_actualBalance - m_actualFee;
+  m_ui->m_amountEdit->setText(CurrencyAdapter::instance().formatAmount(amount));
 }
 
 void OverviewFrame::sendFundsClicked()


### PR DESCRIPTION
### Bug
If you were to attempt to send a transaction, with a total balance of 0 in the wallet, and then proceed to click either 25% or 50% then the sending balance would amount to `18,446,744,073,709.550616`.

### Changes
- I've changed the percentage logic to just divide the balance - fee by 0.25 and 0.5 which when tested, will show a balance of `0.00` after pressing said buttons.
- I use the logic `(balance - fee) / 0.25` using the rules of **BODMAS** so the fee is always accounted for.
