### PR TITLE
Windows build update

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,11 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup VSWhere
-        uses: warrenbuckley/Setup-VSWhere@v1
-
-      - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.0
+      - name: Setup MSBuild.exe
+        uses: warrenbuckley/Setup-MSBuild@v1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup VSWhere
+        uses: warrenbuckley/Setup-VSWhere@v1
+
       - name: Setup msbuild
         uses: microsoft/setup-msbuild@v1.0.0
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,7 +65,7 @@ jobs:
           New-Item "$build_folder\$release_folder" -ItemType Directory
           cd "$build_folder"
 
-          cmake -G "Visual Studio 15 2017" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
+          cmake -G "Visual Studio 15 2017 Win64" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
           msbuild CONCEAL-GUI.sln /p:Configuration=Release /m:2
 
           echo "::set-output name=build_folder::${build_folder}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-windows:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2016
     steps:
       - uses: actions/checkout@v2
 
@@ -65,7 +65,7 @@ jobs:
           New-Item "$build_folder\$release_folder" -ItemType Directory
           cd "$build_folder"
 
-          cmake -G "Visual Studio 16 2019" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
+          cmake -G "Visual Studio 15 2017" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
           msbuild CONCEAL-GUI.sln /p:Configuration=Release /m:2
 
           echo "::set-output name=build_folder::${build_folder}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup VSWhere
+        uses: warrenbuckley/Setup-VSWhere@v1
+
       - name: Setup msbuild
         uses: microsoft/setup-msbuild@v1.0.0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup MSBuild.exe
-        uses: warrenbuckley/Setup-MSBuild@v1s
+        uses: warrenbuckley/Setup-MSBuild@v1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-windows:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2016
     steps:
       - uses: actions/checkout@v2
 
@@ -61,7 +61,7 @@ jobs:
           New-Item "$build_folder\$release_folder" -ItemType Directory
           cd "$build_folder"
 
-          cmake -G "Visual Studio 16 2019" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
+          cmake -G "Visual Studio 15 2017" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
           msbuild CONCEAL-GUI.sln /p:Configuration=Release /m:2
 
           echo "::set-output name=build_folder::${build_folder}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,11 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup VSWhere
-        uses: warrenbuckley/Setup-VSWhere@v1
-
-      - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.0
+      - name: Setup MSBuild.exe
+        uses: warrenbuckley/Setup-MSBuild@v1s
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,7 @@ jobs:
           New-Item "$build_folder\$release_folder" -ItemType Directory
           cd "$build_folder"
 
-          cmake -G "Visual Studio 15 2017" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
+          cmake -G "Visual Studio 15 2017 Win64" -DBoost_INCLUDE_DIR="${env:BOOST_ROOT_1_69_0}"/include ..
           msbuild CONCEAL-GUI.sln /p:Configuration=Release /m:2
 
           echo "::set-output name=build_folder::${build_folder}"


### PR DESCRIPTION
Downgrade Windows build to Visual Studio 2017 (instead of 2019).
No additional dlls are required, (no need to update/reinstall vcredist installed with desktop v6.2.0)