### PR TITLE
Fix screen splitting issue

### DIFF
--- a/src/gui/ui/mainwindow.ui
+++ b/src/gui/ui/mainwindow.ui
@@ -55,7 +55,7 @@ color: #ccc;</string>
    <property name="styleSheet">
     <string notr="true">background-color: #111;</string>
    </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
+   <layout class="QGridLayout" name="gridLayout">
     <property name="spacing">
      <number>0</number>
     </property>
@@ -71,7 +71,7 @@ color: #ccc;</string>
     <property name="bottomMargin">
      <number>0</number>
     </property>
-    <item>
+    <item row="0" column="0">
      <widget class="WalletGui::WelcomeFrame" name="m_welcomeFrame">
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
@@ -79,12 +79,9 @@ color: #ccc;</string>
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
       </property>
-      <property name="lineWidth">
-       <number>0</number>
-      </property>
      </widget>
     </item>
-    <item>
+    <item row="0" column="0">
      <widget class="WalletGui::OverviewFrame" name="m_overviewFrame">
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
@@ -94,7 +91,7 @@ color: #ccc;</string>
       </property>
      </widget>
     </item>
-    <item>
+    <item row="0" column="0">
      <widget class="WalletGui::ReceiveFrame" name="m_receiveFrame">
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
When importing wallet from seed the wallet was displayed only in a half of the screen.