### PR TITLE
GitHub Actions update

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
- build-appimage:
+  build-appimage:
     name: AppImage
     runs-on: ubuntu-18.04
     steps:
@@ -31,8 +31,8 @@ jobs:
           lrelease src/languages/*.ts
           make -j2 build-release
 
-          echo "::set-output name=ccx_version::$ccx_version"
-          echo "::set-output name=release_name::$release_name"
+          echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
+          echo "release_name=${release_name}"  >> $GITHUB_OUTPUT
 
       - name: Create AppImage
         id: appimage
@@ -47,7 +47,7 @@ jobs:
           ls -l $release_name
           sha256=$(shasum -a 256 "$release_name" | awk '{print toupper($1)}')
 
-          echo "::set-output name=sha256::${sha256}"
+          echo "sha256=${sha256}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -10,7 +10,7 @@ jobs:
     name: AppImage
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -49,15 +49,14 @@ jobs:
 
           echo "::set-output name=sha256::${sha256}"
 
-      # since https://github.com/softprops/action-gh-release/pull/145 body is replaced instead of being appended
-      # use v0.1.12 for now
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}
           body: |
             [Download AppImage](../../releases/download/${{ steps.build.outputs.ccx_version }}/${{ steps.build.outputs.release_name }}) **${{ steps.build.outputs.release_name }}**
             `SHA256 : ${{ steps.appimage.outputs.sha256 }}`
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,7 +109,7 @@ jobs:
           mv installer/windows/bin/Conceal*.exe $release_name/
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -159,7 +159,7 @@ jobs:
           echo "::set-output name=release_name::${release_name}"
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.appimage.outputs.release_name }}
           path: ${{ steps.appimage.outputs.release_name }}
@@ -200,7 +200,7 @@ jobs:
           echo "::set-output name=release_name::${release_name}"
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -241,7 +241,7 @@ jobs:
           echo "::set-output name=release_name::${release_name}"
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -282,7 +282,7 @@ jobs:
           echo "::set-output name=release_name::${release_name}"
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -327,7 +327,7 @@ jobs:
           echo "::set-output name=artifact_path::$build_folder/$release_name"
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.artifact_path }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,7 @@ jobs:
           $ccx_version = ((Get-Content CryptoNoteWallet.cmake | Select-String $search) | %{$_ -replace $search, ""}) | %{$_ -replace "\)", ""}
 
           # Update "CMakeLists.txt" with cmake dir
-          $qt5_cmake = "${{ env.Qt5_Dir }}/lib/cmake" -replace '[/]', '\\'
+          $qt5_cmake = "${{ env.Qt5_Dir }}/lib/cmake" -replace '[\\]', '\\' -replace '[/]', '\\'
           $file = "CMakeLists.txt"
           $find = '^set\(CMAKE_PREFIX_PATH.+'
           $replace = "set(CMAKE_PREFIX_PATH `"$($qt5_cmake)`")"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
           Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=${env:BOOST_ROOT}"
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           host: "windows"
           target: "desktop"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,9 +81,9 @@ jobs:
           cmake -G "Visual Studio 16 2019" ..
           msbuild conceal-desktop.sln /p:Configuration=Release /m:2
 
-          echo "::set-output name=build_folder::${build_folder}"
-          echo "::set-output name=release_folder::${release_folder}"
-          echo "::set-output name=release_name::${release_name}"
+          echo "build_folder=${build_folder}" >> $env:GITHUB_OUTPUT
+          echo "release_folder=${release_folder}" >> $env:GITHUB_OUTPUT
+          echo "release_name=${release_name}" >> $env:GITHUB_OUTPUT
 
       - name: Pack
         shell: powershell
@@ -141,7 +141,7 @@ jobs:
           lrelease src/languages/*.ts
           make -j2 build-release
 
-          echo "::set-output name=ccx_version::$ccx_version"
+          echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create AppImage
         id: appimage
@@ -156,7 +156,7 @@ jobs:
           mv Conceal_Desktop*.AppImage ../$release_name/$appimage_name
           cd ..
 
-          echo "::set-output name=release_name::${release_name}"
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
         uses: actions/upload-artifact@v3
@@ -197,7 +197,7 @@ jobs:
           cp conceal-desktop.desktop $release_name
           cp src/images/conceal.png $release_name/icon
 
-          echo "::set-output name=release_name::${release_name}"
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
         uses: actions/upload-artifact@v3
@@ -238,7 +238,7 @@ jobs:
           cp conceal-desktop.desktop $release_name
           cp src/images/conceal.png $release_name/icon
 
-          echo "::set-output name=release_name::${release_name}"
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
         uses: actions/upload-artifact@v3
@@ -279,7 +279,7 @@ jobs:
           cp conceal-desktop.desktop $release_name
           cp src/images/conceal.png $release_name/icon
 
-          echo "::set-output name=release_name::${release_name}"
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
         uses: actions/upload-artifact@v3
@@ -323,8 +323,8 @@ jobs:
           mv *.dmg "$release_name".dmg
           mv "$release_name".dmg "$release_name"
 
-          echo "::set-output name=release_name::${release_name}"
-          echo "::set-output name=artifact_path::$build_folder/$release_name"
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
+          echo "artifact_path=${build_folder}/${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       BOOST_ROOT: C:/tools/boost/x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Setup msbuild
         uses: microsoft/setup-msbuild@v1.0.2
@@ -120,7 +120,7 @@ jobs:
     name: AppImage
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |
@@ -170,7 +170,7 @@ jobs:
     name: Ubuntu 18.04
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |
@@ -211,7 +211,7 @@ jobs:
     name: Ubuntu 20.04
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |
@@ -252,7 +252,7 @@ jobs:
     name: Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |
@@ -293,7 +293,7 @@ jobs:
     name: macOS
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Install Boost
         shell: powershell

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           host: "windows"
           target: "desktop"
-          modules: "qttools5 qtcharts"
+          modules: "qtcharts"
           install-deps: "true"
 
       - name: Clone conceal-core

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@master
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -45,15 +45,14 @@ jobs:
           echo "::set-output name=asset_path::$build_folder/$release_name.zip"
           echo "::set-output name=ccx_version::${ccx_version}"
 
-      # since https://github.com/softprops/action-gh-release/pull/145 body is replaced instead of being appended
-      # use v0.1.12 for now
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: ${{ steps.build.outputs.asset_path }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}
           body: |
             [Download for macOS](../../releases/download/${{ steps.build.outputs.ccx_version }}/${{ steps.build.outputs.release_name }}) **${{ steps.build.outputs.release_name }}**
             `SHA256 : ${{ steps.build.outputs.sha256 }}`
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -10,7 +10,7 @@ jobs:
     name: macOS
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -40,10 +40,10 @@ jobs:
           zip "$release_name".zip "$release_name".dmg
           sha256=$(shasum -a 256 "$release_name".zip | awk '{ print toupper($1) }')
 
-          echo "::set-output name=sha256::${sha256}"
-          echo "::set-output name=release_name::${release_name}.zip"
-          echo "::set-output name=asset_path::$build_folder/$release_name.zip"
-          echo "::set-output name=ccx_version::${ccx_version}"
+          echo "sha256=${sha256}" >> $GITHUB_OUTPUT
+          echo "release_name=${release_name}.zip" >> $GITHUB_OUTPUT
+          echo "asset_path=${build_folder}/${release_name}.zip" >> $GITHUB_OUTPUT
+          echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -43,15 +43,14 @@ jobs:
           echo "::set-output name=release_name::${release_name}.tar.gz"
           echo "::set-output name=ccx_version::${ccx_version}"
 
-      # since https://github.com/softprops/action-gh-release/pull/145 body is replaced instead of being appended
-      # use v0.1.12 for now
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}
           body: |
             [Download for Ubuntu 18.04](../../releases/download/${{ steps.build.outputs.ccx_version }}/${{ steps.build.outputs.release_name }}) **${{ steps.build.outputs.release_name }}**
             `SHA256 : ${{ steps.build.outputs.sha256 }}`
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -39,9 +39,9 @@ jobs:
           tar -czf "$release_name".tar.gz "$release_name"
           sha256=$(shasum -a 256 "$release_name".tar.gz | awk '{print toupper($1)}')
 
-          echo "::set-output name=sha256::${sha256}"
-          echo "::set-output name=release_name::${release_name}.tar.gz"
-          echo "::set-output name=ccx_version::${ccx_version}"
+          echo "sha256=${sha256}" >> $GITHUB_OUTPUT
+          echo "release_name=${release_name}.tar.gz" >> $GITHUB_OUTPUT
+          echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -10,7 +10,7 @@ jobs:
     name: Ubuntu 18.04
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -39,9 +39,9 @@ jobs:
           tar -czf "$release_name".tar.gz "$release_name"
           sha256=$(shasum -a 256 "$release_name".tar.gz | awk '{print toupper($1)}')
 
-          echo "::set-output name=sha256::${sha256}"
-          echo "::set-output name=release_name::${release_name}.tar.gz"
-          echo "::set-output name=ccx_version::${ccx_version}"
+          echo "sha256=${sha256}" >> $GITHUB_OUTPUT
+          echo "release_name=${release_name}.tar.gz" >> $GITHUB_OUTPUT
+          echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -10,7 +10,7 @@ jobs:
     name: Ubuntu 20.04
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -43,15 +43,14 @@ jobs:
           echo "::set-output name=release_name::${release_name}.tar.gz"
           echo "::set-output name=ccx_version::${ccx_version}"
 
-      # since https://github.com/softprops/action-gh-release/pull/145 body is replaced instead of being appended
-      # use v0.1.12 for now
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}
           body: |
             [Download for Ubuntu 20.04](../../releases/download/${{ steps.build.outputs.ccx_version }}/${{ steps.build.outputs.release_name }}) **${{ steps.build.outputs.release_name }}**
             `SHA256 : ${{ steps.build.outputs.sha256 }}`
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -39,9 +39,9 @@ jobs:
           tar -czf "$release_name".tar.gz "$release_name"
           sha256=$(shasum -a 256 "$release_name".tar.gz | awk '{print toupper($1)}')
 
-          echo "::set-output name=sha256::${sha256}"
-          echo "::set-output name=release_name::${release_name}.tar.gz"
-          echo "::set-output name=ccx_version::${ccx_version}"
+          echo "sha256=${sha256}" >> $GITHUB_OUTPUT
+          echo "release_name=${release_name}.tar.gz" >> $GITHUB_OUTPUT
+          echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -10,7 +10,7 @@ jobs:
     name: Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -43,15 +43,14 @@ jobs:
           echo "::set-output name=release_name::${release_name}.tar.gz"
           echo "::set-output name=ccx_version::${ccx_version}"
 
-      # since https://github.com/softprops/action-gh-release/pull/145 body is replaced instead of being appended
-      # use v0.1.12 for now
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}
           body: |
             [Download for Ubuntu 22.04](../../releases/download/${{ steps.build.outputs.ccx_version }}/${{ steps.build.outputs.release_name }}) **${{ steps.build.outputs.release_name }}**
             `SHA256 : ${{ steps.build.outputs.sha256 }}`
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Install Boost
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,11 +26,11 @@ jobs:
           Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=${env:BOOST_ROOT}"
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           host: "windows"
           target: "desktop"
-          modules: "qttools5 qtcharts"
+          modules: "qtcharts"
           install-deps: "true"
 
       - name: Clone conceal-core
@@ -46,7 +46,7 @@ jobs:
           $ccx_version = ((Get-Content CryptoNoteWallet.cmake | Select-String $search) | %{$_ -replace $search, ""}) | %{$_ -replace "\)", ""}
 
           # Update "CMakeLists.txt" with cmake dir
-          $qt5_cmake = "${{ env.Qt5_Dir }}/lib/cmake" -replace '[/]', '\\'
+          $qt5_cmake = "${{ env.Qt5_Dir }}/lib/cmake" -replace '[\\]', '\\' -replace '[/]', '\\'
           $file = "CMakeLists.txt"
           $find = '^set\(CMAKE_PREFIX_PATH.+'
           $replace = "set(CMAKE_PREFIX_PATH `"$($qt5_cmake)`")"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,15 +109,14 @@ jobs:
           echo "::set-output name=release_name::${release_name}.zip"
           echo "::set-output name=asset_path::${asset_path}"
 
-      # since https://github.com/softprops/action-gh-release/pull/145 body is replaced instead of being appended
-      # use v0.1.12 for now
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: ${{ steps.pack.outputs.asset_path }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}
           body: |
             [Download for Windows](../../releases/download/${{ steps.build.outputs.ccx_version }}/${{ steps.pack.outputs.release_name }}) **${{ steps.pack.outputs.release_name }}**
             `SHA256 : ${{ steps.pack.outputs.sha256 }}`
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       BOOST_ROOT: C:/tools/boost/x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Setup msbuild
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -76,10 +76,10 @@ jobs:
           cmake -G "Visual Studio 16 2019" ..
           msbuild conceal-desktop.sln /p:Configuration=Release /m:2
 
-          echo "::set-output name=build_folder::${build_folder}"
-          echo "::set-output name=release_folder::${release_folder}"
-          echo "::set-output name=release_name::${release_name}"
-          echo "::set-output name=ccx_version::${ccx_version}"
+          echo "build_folder=${build_folder}" >> $env:GITHUB_OUTPUT
+          echo "release_folder=${release_folder}" >> $env:GITHUB_OUTPUT
+          echo "release_name=${release_name}" >> $env:GITHUB_OUTPUT
+          echo "ccx_version=${ccx_version}" >> $env:GITHUB_OUTPUT
 
       - name: Pack
         shell: powershell
@@ -105,9 +105,9 @@ jobs:
 
           $sha256 = (Get-FileHash "$release_name.zip").Hash
           $asset_path = "installer/windows/bin/$release_name.zip"
-          echo "::set-output name=sha256::${sha256}"
-          echo "::set-output name=release_name::${release_name}.zip"
-          echo "::set-output name=asset_path::${asset_path}"
+          echo "sha256=${sha256}" >> $env:GITHUB_OUTPUT
+          echo "release_name=${release_name}.zip" >> $env:GITHUB_OUTPUT
+          echo "asset_path=${asset_path}" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
         uses: softprops/action-gh-release@v0.1.15


### PR DESCRIPTION
Fix GitHub Actions warnings
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/