### PR TITLE
Fix crash on parsing ill formatted extra for payment id

### DIFF
--- a/src/CryptoNoteWrapper.cpp
+++ b/src/CryptoNoteWrapper.cpp
@@ -60,11 +60,16 @@ std::string extractPaymentId(const std::string& extra) {
   std::vector<uint8_t> extraVector;
   std::copy(extra.begin(), extra.end(), std::back_inserter(extraVector));
 
-  if (!cn::parseTransactionExtra(extraVector, extraFields)) {
-    throw std::runtime_error("Can't parse extra");
+  std::string result;
+
+  try {
+    if (!cn::parseTransactionExtra(extraVector, extraFields)) {
+      throw std::runtime_error("Can't parse extra");
+    }
+  } catch (...){
+    return result;
   }
 
-  std::string result;
   cn::TransactionExtraNonce extraNonce;
   if (cn::findTransactionExtraFieldByType(extraFields, extraNonce)) {
     crypto::Hash paymentIdHash;


### PR DESCRIPTION
When tx extra has some unexpected chars this will hopefully prevent the wallet from crashing when attempting to extract payment id 