### PR TITLE
GitHub Actions update

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -50,7 +50,7 @@ jobs:
           echo "sha256=${sha256}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Restore Boost
         uses: actions/cache@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Restore Boost
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-boost
         with:
           path: ${{env.BOOST_ROOT}}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -115,7 +115,7 @@ jobs:
           mv installer/windows/bin/Conceal*.exe $release_name/
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -165,7 +165,7 @@ jobs:
           echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.appimage.outputs.release_name }}
           path: ${{ steps.appimage.outputs.release_name }}
@@ -206,7 +206,7 @@ jobs:
           echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -247,7 +247,7 @@ jobs:
           echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.release_name }}
@@ -292,7 +292,7 @@ jobs:
           echo "artifact_path=${build_folder}/${release_name}" >> $GITHUB_OUTPUT
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build.outputs.release_name }}
           path: ${{ steps.build.outputs.artifact_path }}

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -46,7 +46,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.asset_path }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -44,7 +44,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -44,7 +44,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.release_name }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Restore Boost
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-boost
         with:
           path: ${{env.BOOST_ROOT}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Restore Boost
         uses: actions/cache@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -116,7 +116,7 @@ jobs:
           echo "asset_path=${asset_path}" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.pack.outputs.asset_path }}
           name: Conceal Desktop v${{ steps.build.outputs.ccx_version }}


### PR DESCRIPTION
Fix GitHub Actions warnings

- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/